### PR TITLE
Uppercase to Lowercase(for Linux based system)

### DIFF
--- a/sfm3000wedo.cpp
+++ b/sfm3000wedo.cpp
@@ -6,7 +6,7 @@
   Released into the public domain.
 */
 
-#include "SFM3000wedo.h"
+#include "sfm3000wedo.h"
 #include <Wire.h>
 
  


### PR DESCRIPTION
As due to uppercase it was showing error when we were using the library in Linux based system, turning it into the lower case will fix the issue and won't create problem either in Linux and nor in windows.